### PR TITLE
Change custom package URI (git@ instead of git://)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "http-proxy": "^1.11.1",
     "loopback": "^2.14.0",
     "loopback-boot": "^2.6.5",
-    "loopback-component-oauth2": "git://github.com:qbanguy/loopback-component-oauth2.git#master",
+    "loopback-component-oauth2": "git@github.com:qbanguy/loopback-component-oauth2.git#master",
     "loopback-component-passport": "^1.3.0",
     "loopback-connector-postgresql": "^2.0.0",
     "loopback-connector-redis": "0.0.3",


### PR DESCRIPTION
`git://` URI format was causing errors on my computer, using `git@` format solved the issue

My specs:

```
node v0.12.4
npm  v2.11.1
git v2.4.2
```

Error description:

```
npm ERR! Command failed: git clone --template=/home/koren/.npm/_git-remotes/_templates --mirror git://github.com/%3Aqbanguy/loopback-component-oauth2.git /home/koren/.npm/_git-remotes/git-github-com-3Aqbanguy-loopback-component-oauth2-git-ae33e789
npm ERR! Cloning into bare repository '/home/koren/.npm/_git-remotes/git-github-com-3Aqbanguy-loopback-component-oauth2-git-ae33e789'...
npm ERR! fatal: remote error: 
npm ERR!   :qbanguy/loopback-component-oauth2 is not a valid repository name
npm ERR!   Email support@github.com for help
```
